### PR TITLE
Kill the last warnings 🔫 

### DIFF
--- a/app/controllers/TodoController.scala
+++ b/app/controllers/TodoController.scala
@@ -3,12 +3,11 @@ package controllers
 import javax.inject._
 
 import models.{Task, Tasks}
-import play.api.Play.current
-import play.api.i18n.Messages.Implicits._
+import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._
 
 @Singleton
-class TodoController @Inject() (Tasks : Tasks) extends Controller {
+class TodoController @Inject()(val messagesApi: MessagesApi, Tasks: Tasks) extends Controller with I18nSupport {
 
   def tasks = Action {
     Ok(views.html.tasks.index(Tasks.all(), Task.taskForm))


### PR DESCRIPTION
Like hajime mentioned #4, we have below warnings,

```
[warn] .\app\controllers\TodoController.scala:14: method current in object Play is deprecated: This is a static reference to application, use DI instead
[warn] Ok(views.html.tasks.index(Tasks.all(), Task.taskForm))
```

Now I just figured out what is wrong; https://www.playframework.com/documentation/2.5.x/ScalaI18N#externalizing-messages